### PR TITLE
Add the option of a learnable epsilon

### DIFF
--- a/frn.py
+++ b/frn.py
@@ -1,31 +1,48 @@
 # based on the following manuscript
 # https://arxiv.org/abs/1911.09737
+# https://github.com/amirbar/FilterResponseNormalization/blob/master/frn.py
+
+import tensorflow as tf
+from keras.layers import Layer, InputSpec
+from keras import initializers, regularizers, constraints
 
 class FRN(Layer):
+    """
+    Filter Response Normalization
+    """
     def __init__(self,
                  axis=-1,
                  epsilon=1e-6,
+                 learnable_espilon=False,
                  beta_initializer='zeros',
                  gamma_initializer='ones',
+                 epsilon_l_initializer='zeros',
                  beta_regularizer=None,
                  gamma_regularizer=None,
+                 epsilon_l_regularizer=None,
                  beta_constraint=None,
                  gamma_constraint=None,
+                 epsilon_l_constraint=None,
                  **kwargs):
         '''
         :param axis: channels axis
-        :param epsilon: for numeric stability
+        :param epsilon: for numeric stability (should be set to 1e-4 if learnable, 1e-6 otherwise, cf. paper)
+        :param learnable_epsilon: turn epsilon to trainable
         '''
         super(FRN, self).__init__(**kwargs)
         self.supports_masking = True
         self.axis = axis
         self.epsilon = epsilon
+        self.learnable_epsilon = learnable_espilon
         self.beta_initializer = initializers.get(beta_initializer)
         self.gamma_initializer = initializers.get(gamma_initializer)
+        self.epsilon_l_initializer = initializers.get(epsilon_l_initializer)
         self.beta_regularizer = regularizers.get(beta_regularizer)
         self.gamma_regularizer = regularizers.get(gamma_regularizer)
+        self.epsilon_l_regularizer = regularizers.get(epsilon_l_regularizer)
         self.beta_constraint = constraints.get(beta_constraint)
         self.gamma_constraint = constraints.get(gamma_constraint)
+        self.epsilon_l_constraint = constraints.get(epsilon_l_constraint)
 
     def build(self, input_shape):
         dim = input_shape[self.axis]
@@ -50,13 +67,27 @@ class FRN(Layer):
                                     initializer=self.beta_initializer,
                                     regularizer=self.beta_regularizer,
                                     constraint=self.beta_constraint)
+
+        if self.learnable_epsilon:
+            self.epsilon_l = self.add_weight(shape=(1,),
+                                             name='epsilon_l',
+                                             initializer=self.epsilon_l_initializer,
+                                             regularizer=self.epsilon_l_regularizer,
+                                             constraint=self.epsilon_l_constraint)
+
         self.built = True
 
     def call(self, x, **kwargs):
         nu2 = tf.reduce_mean(tf.square(x), axis=list(range(1, x.shape.ndims - 1)), keepdims=True)
+
+        if self.learnable_epsilon:
+            epsilon = self.epsilon + tf.abs(self.epsilon_l)
+        else:
+            epsilon = self.epsilon
+
         # Perform FRN.
-        x = x * tf.rsqrt(nu2 + tf.abs(self.epsilon))
-        # Return after applying the Offset-ReLU non-linearity.
+        x = x * tf.rsqrt(nu2 + tf.abs(epsilon))
+
         return self.gamma * x + self.beta
 
     def get_config(self):
@@ -64,10 +95,13 @@ class FRN(Layer):
             'epsilon': self.epsilon,
             'beta_initializer': initializers.serialize(self.beta_initializer),
             'gamma_initializer': initializers.serialize(self.gamma_initializer),
+            'epsilon_l_initializer': initializers.serialize(self.epsilon_l_initializer),
             'beta_regularizer': regularizers.serialize(self.beta_regularizer),
             'gamma_regularizer': regularizers.serialize(self.gamma_regularizer),
+            'epsilon_l_regularizer': regularizers.serialize(self.epsilon_l_regularizer),
             'beta_constraint': constraints.serialize(self.beta_constraint),
             'gamma_constraint': constraints.serialize(self.gamma_constraint),
+            'epsilon_l_constraint': constraints.serialize(self.epsilon_l_constraint),
         }
         base_config = super(FRN, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
@@ -76,7 +110,10 @@ class FRN(Layer):
         return input_shape
 
 
-class ThresholdedLinearUnit(Layer):
+class TLU(Layer):
+    """
+    Thresholded Linear Unit: augmented ReLU with a learned threshold (tau)
+    """
     def __init__(self,
                  axis=-1,
                  tau_initializer='zeros',
@@ -86,7 +123,7 @@ class ThresholdedLinearUnit(Layer):
         '''
         :param axis: channels axis
         '''
-        super(ThresholdedLinearUnit, self).__init__(**kwargs)
+        super(TLU, self).__init__(**kwargs)
         self.axis = axis
         self.tau_initializer = initializers.get(tau_initializer)
         self.tau_regularizer = regularizers.get(tau_regularizer)
@@ -122,7 +159,7 @@ class ThresholdedLinearUnit(Layer):
             'tau_regularizer': regularizers.serialize(self.tau_regularizer),
             'tau_constraint': constraints.serialize(self.tau_constraint)
         }
-        base_config = super(ThresholdedLinearUnit, self).get_config()
+        base_config = super(TLU, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
 
     def compute_output_shape(self, input_shape):

--- a/frn.py
+++ b/frn.py
@@ -13,7 +13,7 @@ class FRN(Layer):
     def __init__(self,
                  axis=-1,
                  epsilon=1e-6,
-                 learnable_espilon=False,
+                 learnable_epsilon=False,
                  beta_initializer='zeros',
                  gamma_initializer='ones',
                  epsilon_l_initializer='zeros',
@@ -33,7 +33,7 @@ class FRN(Layer):
         self.supports_masking = True
         self.axis = axis
         self.epsilon = epsilon
-        self.learnable_epsilon = learnable_espilon
+        self.learnable_epsilon = learnable_epsilon
         self.beta_initializer = initializers.get(beta_initializer)
         self.gamma_initializer = initializers.get(gamma_initializer)
         self.epsilon_l_initializer = initializers.get(epsilon_l_initializer)


### PR DESCRIPTION
From the paper (3.3. Parameterizing epsilon): 
> Appropriate value of epsilon becomes crucial for models that are fully connected or lead to 1x1 activation maps. Empirically, we turn epsilon into a learnable parameter (initialized at 10^4 ) for such models.